### PR TITLE
Pyxel launch script example: add missing get_controls

### DIFF
--- a/content/markdown/packaging.markdown
+++ b/content/markdown/packaging.markdown
@@ -507,6 +507,8 @@ source $controlfolder/control.txt
 
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
+get_controls
+
 GAMEDIR=/$directory/ports/portfolder/
 CONFDIR="$GAMEDIR/conf"
 PYXEL_PKG="gamename.pyxapp"


### PR DESCRIPTION
Obviously I've forgotten it in the example as well 👀