### PR TITLE
Add Godot 4 runtimes to port.json Generator

### DIFF
--- a/website/port-json.html
+++ b/website/port-json.html
@@ -223,6 +223,9 @@
                     <option value="frt_3.6.squashfs">Godot / FRT 3.6</option>
                     <option value="frt_4.0.4.squashfs">Godot / FRT 4.0.4</option>
                     <option value="frt_4.1.3.squashfs">Godot / FRT 4.1.3</option>
+                    <option value="godot_4.2.2.squashfs">Godot 4.2.2</option>
+                    <option value="godot_4.3.squashfs">Godot 4.3</option>
+                    <option value="godot_4.4.squashfs">Godot 4.4</option>
                   </optgroup>
                   <optgroup label="Java">
                     <option value="zulu11.48.21-ca-jdk11.0.11-linux.aarch64.squashfs">Java jdk11.0.11</option>


### PR DESCRIPTION
Just adds the Godot 4.2.2, 4.3 and 4.4 runtimes to the port.json Generator page.