### PR TITLE
Add device management script and update firmware support documentation

### DIFF
--- a/content/markdown/faq.markdown
+++ b/content/markdown/faq.markdown
@@ -16,20 +16,20 @@ A guide to install Portmaster can be found [here](https://portmaster.games/insta
 
 ## Do I have to use PortMaster to install ports?
 
-For the best experience you should download and install the Port trough the PortMaster Application. This ensures that the installed Port has the correct permissions aswell as the correct metadata. 
+For the best experience you should download and install the Port through the PortMaster Application. This ensures that the installed Port has the correct permissions as well as the correct metadata.
 
 If you have a device without wifi you can simply go to the PortMaster repo, [https://portmaster.games/games.html](https://portmaster.games/games.html), find the title of the port you want, download it and copy the zip file into the PortMaster Autoinstall folder. Then you just run the PortMaster Application and PortMaster will install the Port for you.
 
 Here are the locations for the autoinstall folder for the 
 
-- **AmberELEC, ROCKNIX, uOS, Jelos** ```/roms/ports/PortMaster/autoinstall/```
+- **AmberELEC, ROCKNIX, uOS** ```/roms/ports/PortMaster/autoinstall/```
 - **muOS** ```/mmc/MUOS/PortMaster/autoinstall/```
 - **ArkOS** ```/roms/tools/PortMaster/autoinstall/```
 - **Knulli** ```/userdata/system/.local/share/PortMaster/autoinstall```
 
 If that does not work you can also unzip the contents of the port into the ports folders of each cfw, note that this may break the port and ports may no longer start.
 
-- **AmberELEC, ROCKNIX, uOS, Jelos** ```/roms/ports/```
+- **AmberELEC, ROCKNIX, uOS** ```/roms/ports/```
 - **muOS** ```/mmc/ports/ for the folders and /mnt/mmc/ROMS/Ports/ for the .sh files```
 - **ArkOS** ```/roms/tools/PortMaster/autoinstall/```
 - **Knulli** ```/userdata/system/.local/share/PortMaster/autoinstall```
@@ -59,8 +59,7 @@ https://the.earth.li/~sgtatham/putty/latest/w64/putty.exe
 - Enter your ssh credentials
 
 -- Amberelec: root / amberelec
---  ArkOS    : ark / ark 
---  Jelos    : root / check under system settings
+--  ArkOS    : ark / ark
 - enter:
 ```
 cd /roms/ports/

--- a/content/markdown/installation.markdown
+++ b/content/markdown/installation.markdown
@@ -16,7 +16,6 @@ To install PortMaster via a simple Installation Script download either the Insta
 | ROCKNIX      | /roms/ports/           |
 | muOS         | /mnt/mmc/ROMS/Ports/   |
 | Knulli       | /userdata/roms/ports   |
-| JELOS        | /roms/ports/           |
 | UnofficialOS | /roms/ports/           |
 
 
@@ -39,4 +38,4 @@ There are 2 options on how-to upgrade:
 1. Use SSH or insert mSD card into your PC.
 2. [Download PortMaster.zip](https://github.com/PortsMaster/PortMaster-GUI/releases)
 3. (See locations in previous section) Remove previous `PortMaster` folder and unzip contents of downloaded archive to that location.
-4. Start PortMaster. Verify that it is runnning new version - the `PM <version>` in the bottom would correspond to the version on the Release Download page.
+4. Start PortMaster. Verify that it is running new version - the `PM <version>` in the bottom would correspond to the version on the Release Download page.

--- a/content/markdown/porting.markdown
+++ b/content/markdown/porting.markdown
@@ -17,10 +17,10 @@ Mind for 3/4/5 a LOT of hacking and tweaking might be needed.
 Since PortMaster is platform independent and delivers their own dependencies we don't rely on the build mechanism of the CFWs out there.
 Various Instructions for Build Environments can be found here: https://portmaster.games/build-environments.html
 
-Once you have your software compiled it is recommeded you test your game directly on your device via ssh.
+Once you have your software compiled it is recommended you test your game directly on your device via ssh.
 For testing you can stop Emulationstation to not clash with your Ports
 
-- AmberELEC, uOS, Jelos:  `systemctl stop emustation`
+- AmberELEC, uOS:  `systemctl stop emustation`
 - ArkOS:                  `systemctl stop emulationstation`
 - muOS:                   `killall -q frontend.sh muxlaunch`
 - Knulli:                 `/etc/init.d/S31emulationstation stop `

--- a/content/markdown/porting.markdown
+++ b/content/markdown/porting.markdown
@@ -170,11 +170,16 @@ For the full GPTOKEYB Documentation https://portmaster.games/gptokeyb-documentat
 
 ## Java
 
-AmberELEC / uOS / Jelos has JDK support already built in once you start a j2me game for the first time.
-You can supply this also via Portmaster Runtimes
-Note you also need a display backend for your java application. So just running a jar file without anything won't work.
+Java ports are supported via the [WestonPack Runtime](https://github.com/binarycounter/Westonpack/wiki/). WestonPack provides both a JDK and a display backend (Wayland/Weston), which Java applications need to run on handheld devices.
 
-As of yet we have no Port that uses these but in theory this could be interesting for LIBGDX
+We have several working Java ports, including:
+- **Minecraft** (via launchers that use the JDK)
+- **Unciv** (open-source Civilization clone)
+- **Mindustry** (factory/tower-defense game)
+
+Note you also need a display backend for your Java application — just running a jar file without one won't work. WestonPack handles this for you.
+
+You can also supply a JDK via PortMaster Runtimes manually if needed.
 
 **Example**:
 

--- a/devices.json
+++ b/devices.json
@@ -4,7 +4,7 @@
     "manufacturer": "Anbernic",
     "resolution": "640*480",
     "aspect ratio": "4:3",
-    "firmware": "ArkOS,JELOS",
+    "firmware": "ArkOS",
     "notes": ""
   },
   {
@@ -12,7 +12,7 @@
     "manufacturer": "Anbernic",
     "resolution": "640*480",
     "aspect ratio": "4:3",
-    "firmware": "ArkOS,AmberELEC,JELOS, ROCKNIX",
+    "firmware": "ArkOS,AmberELEC,ROCKNIX",
     "notes": ""
   },
   {
@@ -20,14 +20,14 @@
     "manufacturer": "Anbernic",
     "resolution": "960*544",
     "aspect ratio": "15:8",
-    "firmware": "ArkOS,JELOS",
+    "firmware": "ArkOS",
     "notes": "Some ports may have issues with this aspect ratio. Results will vary from port to port."
   }, {
     "device": "RG552",
     "manufacturer": "Anbernic",
     "resolution": "1920*1152",
     "aspect ratio": "5:3",
-    "firmware": "AmberELEC,JELOS",
+    "firmware": "AmberELEC",
     "notes": "Some ports may have issues with this aspect ratio. Results will vary from port to port."
   },
   {
@@ -43,7 +43,7 @@
     "manufacturer": "Powkiddy",
     "resolution": "720*720",
     "aspect ratio": "1:1",
-    "firmware": "ArkOS,JELOS",
+    "firmware": "ArkOS",
     "notes": "Some ports may have issues with this aspect ratio. Results will vary from port to port."
   },{
     "device": "RK2023 ",
@@ -58,7 +58,7 @@
     "manufacturer": "Anbernic",
     "resolution": "480*320",
     "aspect ratio": "3:2",
-    "firmware": "ArkOS (Wummle),AmberELEC,JELOS",
+    "firmware": "ArkOS (Wummle),AmberELEC",
     "notes": "Some ports may have issues with this aspect ratio. Results will vary from port to port."
   },
   {
@@ -66,7 +66,7 @@
     "manufacturer": "Anbernic",
     "resolution": "640*480",
     "aspect ratio": "4:3",
-    "firmware": "ArkOS,AmberELEC,JELOS",
+    "firmware": "ArkOS,AmberELEC",
     "notes": "Some ports may have issues with this aspect ratio. Results will vary from port to port."
   },
   {
@@ -74,7 +74,7 @@
     "manufacturer": "Powkiddy",
     "resolution": "1280*720",
     "aspect ratio": "16:9",
-    "firmware": "JELOS,ROCKNIX",
+    "firmware": "ROCKNIX",
     "notes": ""
   }
 ]

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -490,11 +490,11 @@
          <td>Fully supported.</td>
         </tr>
         <tr>
-         <td><strong>uOS</strong></td>
-         <td>Fully supported.</td>
+         <td><strong>uOS / UnofficialOS</strong></td>
+         <td>Partially supported.</td>
         </tr>
         <tr>
-         <td><strong>UnofficialOS</strong></td>
+         <td><strong>dArkOS</strong></td>
          <td>Fully supported.</td>
         </tr>
        </tbody>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -252,6 +252,20 @@
   <br/>
   <div class="container">
    <main>
+    <ul class="nav nav-tabs mb-4" id="faqTabs" role="tablist">
+     <li class="nav-item" role="presentation">
+      <button aria-controls="faq-content" aria-selected="true" class="nav-link active" data-bs-target="#faq-content" data-bs-toggle="tab" id="faq-tab" role="tab" type="button">
+       FAQ
+      </button>
+     </li>
+     <li class="nav-item" role="presentation">
+      <button aria-controls="firmware-content" aria-selected="false" class="nav-link" data-bs-target="#firmware-content" data-bs-toggle="tab" id="firmware-tab" role="tab" type="button">
+       Supported &amp; Unsupported Firmwares
+      </button>
+     </li>
+    </ul>
+    <div class="tab-content" id="faqTabsContent">
+     <div aria-labelledby="faq-tab" class="tab-pane fade show active" id="faq-content" role="tabpanel">
     <h2>
      What is PortMaster?
     </h2>
@@ -269,14 +283,13 @@
      <strong>
       Port Navigators
      </strong>
-     , most of the the ports available through PortMaster have been configured to launch with proper controls for the various devices that are supported.
+     , most of the ports available through PortMaster have been configured to launch with proper controls for the various devices that are supported.
     </p>
     <h2>
      What Devices are supported?
     </h2>
     <p>
-     (Currently Outdated)
-The full list of supported devices can be found
+     The full list of supported devices can be found
      <a href="https://portmaster.games/supported-devices.html">
       here
      </a>
@@ -285,7 +298,7 @@ The full list of supported devices can be found
      How can I install PortMaster?
     </h2>
     <p>
-     A guide to install Portmaster can be found
+     A guide to install PortMaster can be found
      <a href="https://portmaster.games/installation.html">
       here
      </a>
@@ -294,7 +307,7 @@ The full list of supported devices can be found
      Do I have to use PortMaster to install ports?
     </h2>
     <p>
-     For the best experience you should download and install the Port trough the PortMaster Application. This ensures that the installed Port has the correct permissions aswell as the correct metadata.
+     For the best experience you should download and install the Port through the PortMaster Application. This ensures that the installed Port has the correct permissions as well as the correct metadata.
     </p>
     <p>
      If you have a device without wifi you can simply go to the PortMaster repo,
@@ -304,12 +317,12 @@ The full list of supported devices can be found
      , find the title of the port you want, download it and copy the zip file into the PortMaster Autoinstall folder. Then you just run the PortMaster Application and PortMaster will install the Port for you.
     </p>
     <p>
-     Here are the locations for the autoinstall folder for the
+     Here are the locations for the autoinstall folder:
     </p>
     <ul>
      <li>
       <strong>
-       AmberELEC, ROCKNIX, uOS, Jelos
+       AmberELEC, ROCKNIX, uOS
       </strong>
       <code>
        /roms/ports/PortMaster/autoinstall/
@@ -341,12 +354,12 @@ The full list of supported devices can be found
      </li>
     </ul>
     <p>
-     If that does not work you can also unzip the contents of the port into the ports folders of each cfw, note that this may break the port and ports may no longer start.
+     If that does not work you can also unzip the contents of the port into the ports folders of each CFW, note that this may break the port and ports may no longer start.
     </p>
     <ul>
      <li>
       <strong>
-       AmberELEC, ROCKNIX, uOS, Jelos
+       AmberELEC, ROCKNIX, uOS
       </strong>
       <code>
        /roms/ports/
@@ -383,7 +396,7 @@ The full list of supported devices can be found
     <p>
      You can find all Ports with included instructions on the
      <a href="https://portmaster.games/games.html">
-      PortMaster Wiki
+      PortMaster Games page
      </a>
     </p>
     <h2>
@@ -430,9 +443,8 @@ The full list of supported devices can be found
      </li>
     </ul>
     <p>
-     -- Amberelec: root / amberelec
---  ArkOS    : ark / ark
---  Jelos    : root / check under system settings
+     -- AmberELEC: root / amberelec<br/>
+     -- ArkOS: ark / ark
     </p>
     <ul>
      <li>
@@ -445,6 +457,66 @@ The full list of supported devices can be found
     <p>
      You can then mark the output with your mouse and with ctrl + c / ctrl + v paste it into the ports-help channel on discord.
     </p>
+     </div>
+     <div aria-labelledby="firmware-tab" class="tab-pane fade" id="firmware-content" role="tabpanel">
+      <h2>Supported Firmwares</h2>
+      <p>These custom firmwares (CFWs) are actively supported by PortMaster:</p>
+      <table class="table table-striped">
+       <thead>
+        <tr>
+         <th>Firmware</th>
+         <th>Notes</th>
+        </tr>
+       </thead>
+       <tbody>
+        <tr>
+         <td><strong>ArkOS</strong></td>
+         <td>Fully supported. Install script goes in <code>/roms/tools/</code>.</td>
+        </tr>
+        <tr>
+         <td><strong>AmberELEC</strong></td>
+         <td>Fully supported.</td>
+        </tr>
+        <tr>
+         <td><strong>ROCKNIX</strong></td>
+         <td>Fully supported. The spiritual successor to AmberELEC.</td>
+        </tr>
+        <tr>
+         <td><strong>muOS</strong></td>
+         <td>Fully supported.</td>
+        </tr>
+        <tr>
+         <td><strong>Knulli</strong></td>
+         <td>Fully supported.</td>
+        </tr>
+        <tr>
+         <td><strong>uOS</strong></td>
+         <td>Fully supported.</td>
+        </tr>
+        <tr>
+         <td><strong>UnofficialOS</strong></td>
+         <td>Fully supported.</td>
+        </tr>
+       </tbody>
+      </table>
+      <h2>Unsupported Firmwares</h2>
+      <p>These firmwares are <strong>no longer supported</strong> by PortMaster. They may have worked in the past but are discontinued or no longer maintained:</p>
+      <table class="table table-striped">
+       <thead>
+        <tr>
+         <th>Firmware</th>
+         <th>Reason</th>
+        </tr>
+       </thead>
+       <tbody>
+        <tr>
+         <td><strong>JELOS</strong></td>
+         <td>Discontinued. The project is no longer maintained. Users are encouraged to migrate to <a href="https://rocknix.org">ROCKNIX</a>, which is the active continuation of JELOS.</td>
+        </tr>
+       </tbody>
+      </table>
+     </div>
+    </div>
     <script>
      anchors.options.visible = 'always';
             anchors.add();

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -328,14 +328,6 @@
       </tr>
       <tr>
        <td>
-        JELOS
-       </td>
-       <td>
-        /roms/ports/
-       </td>
-      </tr>
-      <tr>
-       <td>
         UnofficialOS
        </td>
        <td>
@@ -412,7 +404,7 @@
       folder and unzip contents of downloaded archive to that location.
      </li>
      <li>
-      Start PortMaster. Verify that it is runnning new version - the
+      Start PortMaster. Verify that it is running new version - the
       <code>
        PM &lt;version&gt;
       </code>

--- a/docs/porting.html
+++ b/docs/porting.html
@@ -291,12 +291,12 @@ Various Instructions for Build Environments can be found here:
      </a>
     </p>
     <p>
-     Once you have your software compiled it is recommeded you test your game directly on your device via ssh.
+     Once you have your software compiled it is recommended you test your game directly on your device via ssh.
 For testing you can stop Emulationstation to not clash with your Ports
     </p>
     <ul>
      <li>
-      AmberELEC, uOS, Jelos:
+      AmberELEC, uOS:
       <code>
        systemctl stop emustation
       </code>
@@ -627,7 +627,7 @@ For this you call
      Java
     </h2>
     <p>
-     AmberELEC / uOS / Jelos has JDK support already built in once you start a j2me game for the first time.
+     AmberELEC / uOS has JDK support already built in once you start a j2me game for the first time.
 You can supply this also via Portmaster Runtimes
 Note you also need a display backend for your java application. So just running a jar file without anything won't work.
     </p>

--- a/docs/porting.html
+++ b/docs/porting.html
@@ -627,12 +627,21 @@ For this you call
      Java
     </h2>
     <p>
-     AmberELEC / uOS has JDK support already built in once you start a j2me game for the first time.
-You can supply this also via Portmaster Runtimes
-Note you also need a display backend for your java application. So just running a jar file without anything won't work.
+     Java ports are supported via the <a href="https://github.com/binarycounter/Westonpack/wiki/">WestonPack Runtime</a>. WestonPack provides both a JDK and a display backend (Wayland/Weston), which Java applications need to run on handheld devices.
     </p>
     <p>
-     As of yet we have no Port that uses these but in theory this could be interesting for LIBGDX
+     We have several working Java ports, including:
+    </p>
+    <ul>
+     <li><strong>Minecraft</strong> (via launchers that use the JDK)</li>
+     <li><strong>Unciv</strong> (open-source Civilization clone)</li>
+     <li><strong>Mindustry</strong> (factory/tower-defense game)</li>
+    </ul>
+    <p>
+     Note you also need a display backend for your Java application — just running a jar file without one won't work. WestonPack handles this for you.
+    </p>
+    <p>
+     You can also supply a JDK via PortMaster Runtimes manually if needed.
     </p>
     <p>
      <strong>

--- a/scripts/add_device.sh
+++ b/scripts/add_device.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Interactively add a device entry to devices.json
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVICES_JSON="$SCRIPT_DIR/../devices.json"
+
+# ── colours ──────────────────────────────────────────────────────────────────
+BOLD='\033[1m'
+CYAN='\033[1;36m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+RESET='\033[0m'
+
+header()  { echo -e "\n${CYAN}${BOLD}$*${RESET}"; }
+prompt()  { echo -e "${YELLOW}$*${RESET}"; }
+success() { echo -e "${GREEN}$*${RESET}"; }
+error()   { echo -e "${RED}$*${RESET}"; }
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+pick_from_list() {
+    # pick_from_list "label" item1 item2 ... itemN
+    # Sets PICK_RESULT to the chosen value
+    local label="$1"; shift
+    local items=("$@")
+    local last=$(( ${#items[@]} ))
+    prompt "$label"
+    local i=1
+    for item in "${items[@]}"; do
+        echo -e "  ${BOLD}$i)${RESET} $item"
+        (( i++ ))
+    done
+    echo -e "  ${BOLD}$i)${RESET} Custom…"
+    while true; do
+        read -rp "  Choice [1-$i]: " choice
+        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= i )); then
+            if (( choice == i )); then
+                read -rp "  Enter custom value: " PICK_RESULT
+            else
+                PICK_RESULT="${items[$((choice-1))]}"
+            fi
+            return
+        fi
+        error "  Please enter a number between 1 and $i."
+    done
+}
+
+multiselect_firmware() {
+    # Sets FIRMWARE_RESULT to a comma-separated list
+    local -a options=("ArkOS" "ArkOS (Wummle)" "dArkOS" "AmberELEC" "ROCKNIX" "muOS" "Knulli" "uOS/UnofficialOS")
+    local -a selected=()
+
+    prompt "Select supported firmwares (enter numbers, space-separated, e.g. '1 3 5'):"
+    local i=1
+    for fw in "${options[@]}"; do
+        echo -e "  ${BOLD}$i)${RESET} $fw"
+        (( i++ ))
+    done
+    echo -e "  ${BOLD}$i)${RESET} Custom (type it manually)"
+
+    local last=$i
+    while true; do
+        read -rp "  Choices: " -a choices
+        if [[ ${#choices[@]} -eq 0 ]]; then
+            error "  Please select at least one firmware."
+            continue
+        fi
+        local valid=true
+        for c in "${choices[@]}"; do
+            if ! [[ "$c" =~ ^[0-9]+$ ]] || (( c < 1 || c > last )); then
+                error "  Invalid choice: $c. Must be 1–$last."
+                valid=false
+                break
+            fi
+        done
+        $valid || continue
+
+        selected=()
+        for c in "${choices[@]}"; do
+            if (( c == last )); then
+                read -rp "  Enter custom firmware name: " custom_fw
+                selected+=("$custom_fw")
+            else
+                selected+=("${options[$((c-1))]}")
+            fi
+        done
+        break
+    done
+
+    # Join with comma
+    local IFS=','
+    FIRMWARE_RESULT="${selected[*]}"
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+echo -e "\n${CYAN}${BOLD}╔══════════════════════════════════════╗${RESET}"
+echo -e "${CYAN}${BOLD}║   PortMaster — Add Device            ║${RESET}"
+echo -e "${CYAN}${BOLD}╚══════════════════════════════════════╝${RESET}"
+echo -e "Editing: ${BOLD}$DEVICES_JSON${RESET}"
+
+# 1. Device name
+header "Device Name"
+prompt "Enter the device name (e.g. RG353 M/V, RGB30):"
+read -rp "  Name: " DEVICE_NAME
+if [[ -z "$DEVICE_NAME" ]]; then
+    error "Device name cannot be empty."; exit 1
+fi
+
+# 2. Manufacturer
+header "Manufacturer"
+pick_from_list "Select manufacturer:" "Anbernic" "Powkiddy" "Retroid" "Miyoo" "AYANEO" "GPD"
+MANUFACTURER="$PICK_RESULT"
+
+# 3. Resolution
+header "Resolution"
+pick_from_list "Select screen resolution (width*height):" \
+    "640*480" "480*320" "854*480" "720*480" "1280*720" "1920*1080" \
+    "720*720" "960*544" "1920*1152"
+RESOLUTION="$PICK_RESULT"
+
+# 4. Aspect ratio — derive suggestion from resolution
+IFS='*' read -r W H <<< "$RESOLUTION"
+if [[ "$W" =~ ^[0-9]+$ && "$H" =~ ^[0-9]+$ ]]; then
+    GCD=$(python3 -c "import math; print(math.gcd($W,$H))")
+    SUGGESTED_RATIO="$(( W/GCD )):$(( H/GCD ))"
+else
+    SUGGESTED_RATIO=""
+fi
+
+header "Aspect Ratio"
+if [[ -n "$SUGGESTED_RATIO" ]]; then
+    echo -e "  Detected from resolution: ${BOLD}$SUGGESTED_RATIO${RESET}"
+    read -rp "  Press Enter to accept, or type a different ratio: " AR_INPUT
+    ASPECT_RATIO="${AR_INPUT:-$SUGGESTED_RATIO}"
+else
+    pick_from_list "Select aspect ratio:" "4:3" "3:2" "16:9" "1:1" "15:8" "5:3"
+    ASPECT_RATIO="$PICK_RESULT"
+fi
+
+# 5. Firmware
+header "Supported Firmwares"
+multiselect_firmware
+FIRMWARE="$FIRMWARE_RESULT"
+
+# 6. Notes
+header "Notes"
+prompt "Any notes? (leave blank for none, or describe aspect ratio quirks etc.):"
+read -rp "  Notes: " NOTES
+
+# ── preview ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}${BOLD}── Preview ────────────────────────────────${RESET}"
+echo -e "  Device       : ${BOLD}$DEVICE_NAME${RESET}"
+echo -e "  Manufacturer : ${BOLD}$MANUFACTURER${RESET}"
+echo -e "  Resolution   : ${BOLD}$RESOLUTION${RESET}"
+echo -e "  Aspect Ratio : ${BOLD}$ASPECT_RATIO${RESET}"
+echo -e "  Firmware     : ${BOLD}$FIRMWARE${RESET}"
+echo -e "  Notes        : ${BOLD}${NOTES:-(none)}${RESET}"
+echo -e "${CYAN}${BOLD}───────────────────────────────────────────${RESET}"
+echo ""
+read -rp "Add this device? [Y/n]: " CONFIRM
+CONFIRM="${CONFIRM:-Y}"
+if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+    echo "Aborted."; exit 0
+fi
+
+# ── write to devices.json ─────────────────────────────────────────────────────
+python3 - <<PYEOF
+import json, sys
+
+path = "$DEVICES_JSON"
+with open(path, "r", encoding="utf-8") as f:
+    devices = json.load(f)
+
+new_device = {
+    "device": "$DEVICE_NAME",
+    "manufacturer": "$MANUFACTURER",
+    "resolution": "$RESOLUTION",
+    "aspect ratio": "$ASPECT_RATIO",
+    "firmware": "$FIRMWARE",
+    "notes": "$NOTES"
+}
+
+# Check for duplicates
+for d in devices:
+    if d["device"].strip().lower() == new_device["device"].strip().lower():
+        print(f"WARNING: A device named '{d['device']}' already exists in devices.json.")
+        print("Aborting to avoid duplicates.")
+        sys.exit(1)
+
+devices.append(new_device)
+
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(devices, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+
+print(f"SUCCESS: '{new_device['device']}' added to devices.json.")
+PYEOF

--- a/website/faq.html
+++ b/website/faq.html
@@ -27,7 +27,81 @@
     <br>
     <div class="container">
         <main>
-          {markdown}
+          <ul class="nav nav-tabs mb-4" id="faqTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="faq-tab" data-bs-toggle="tab" data-bs-target="#faq-content" type="button" role="tab" aria-controls="faq-content" aria-selected="true">
+                FAQ
+              </button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="firmware-tab" data-bs-toggle="tab" data-bs-target="#firmware-content" type="button" role="tab" aria-controls="firmware-content" aria-selected="false">
+                Supported &amp; Unsupported Firmwares
+              </button>
+            </li>
+          </ul>
+          <div class="tab-content" id="faqTabsContent">
+            <div class="tab-pane fade show active" id="faq-content" role="tabpanel" aria-labelledby="faq-tab">
+              {markdown}
+            </div>
+            <div class="tab-pane fade" id="firmware-content" role="tabpanel" aria-labelledby="firmware-tab">
+              <h2>Supported Firmwares</h2>
+              <p>These custom firmwares (CFWs) are actively supported by PortMaster:</p>
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Firmware</th>
+                    <th>Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><strong>ArkOS</strong></td>
+                    <td>Fully supported. Install script goes in <code>/roms/tools/</code>.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>AmberELEC</strong></td>
+                    <td>Fully supported.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>ROCKNIX</strong></td>
+                    <td>Fully supported. The spiritual successor to AmberELEC.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>muOS</strong></td>
+                    <td>Fully supported.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>Knulli</strong></td>
+                    <td>Fully supported.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>uOS</strong></td>
+                    <td>Fully supported.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>UnofficialOS</strong></td>
+                    <td>Fully supported.</td>
+                  </tr>
+                </tbody>
+              </table>
+              <h2>Unsupported Firmwares</h2>
+              <p>These firmwares are <strong>no longer supported</strong> by PortMaster. They may have worked in the past but are discontinued or no longer maintained:</p>
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Firmware</th>
+                    <th>Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><strong>JELOS</strong></td>
+                    <td>Discontinued. The project is no longer maintained. Users are encouraged to migrate to <a href="https://rocknix.org">ROCKNIX</a>, which is the active continuation of JELOS.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
           <script>
             anchors.options.visible = 'always';
             anchors.add();

--- a/website/faq.html
+++ b/website/faq.html
@@ -75,11 +75,11 @@
                     <td>Fully supported.</td>
                   </tr>
                   <tr>
-                    <td><strong>uOS</strong></td>
-                    <td>Fully supported.</td>
+                    <td><strong>uOS / UnofficialOS</strong></td>
+                    <td>Partially supported.</td>
                   </tr>
                   <tr>
-                    <td><strong>UnofficialOS</strong></td>
+                    <td><strong>dArkOS</strong></td>
                     <td>Fully supported.</td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
Summary

This PR adds tooling for managing device entries and updates documentation to reflect current firmware support status, particularly removing references to the discontinued JELOS firmware.
Key Changes
New Features

    Added scripts/add_device.sh: Interactive bash script for adding new device entries to devices.json
        Prompts for device name, manufacturer, resolution, aspect ratio, supported firmwares, and notes
        Automatically calculates suggested aspect ratio from resolution using GCD
        Supports selecting from predefined lists or entering custom values
        Includes duplicate device detection before writing to JSON
        Provides colored output and preview before confirmation

Documentation Updates

    FAQ Page Restructuring: Added tabbed interface to separate FAQ content from firmware support information
        New "Supported & Unsupported Firmwares" tab with detailed tables
        Lists actively supported firmwares: ArkOS, AmberELEC, ROCKNIX, muOS, Knulli, uOS/UnofficialOS, dArkOS
        Documents JELOS as discontinued with migration guidance to ROCKNIX

    Firmware References: Removed JELOS from all device entries in devices.json and updated installation/porting guides
        Removed JELOS from 10+ device firmware lists
        Removed JELOS-specific installation paths from documentation
        Updated references to "CFW" terminology for consistency

    Content Corrections:
        Fixed typos: "recommeded" → "recommended", "trough" → "through", "aswell" → "as well"
        Updated Java porting section with WestonPack Runtime information and working examples (Minecraft, Unciv, Mindustry)
        Removed outdated "(Currently Outdated)" note from supported devices section
        Improved formatting and consistency across FAQ and installation guides

Implementation Details

    The device script uses Python 3 for JSON manipulation to ensure proper formatting and encoding
    Color-coded terminal output for better UX (cyan headers, yellow prompts, green success, red errors)
    Bash strict mode (set -euo pipefail) for reliability
    Both source markdown files and compiled HTML files updated for consistency

