### PR TITLE
Lighter initial page load

### DIFF
--- a/website/games.html
+++ b/website/games.html
@@ -14,7 +14,6 @@
   <script defer src="js/color-modes.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"></script>
-  <script defer src="js/cmark-gfm.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
   <script defer src="js/shared.js"></script>
   <script defer src="js/games.js"></script>

--- a/website/js/games.js
+++ b/website/js/games.js
@@ -1,3 +1,7 @@
+const WINDOW_SIZE = 60;
+// Extend a screen ahead so scrolling never waits on the next window.
+const WINDOW_ROOT_MARGIN = '800px';
+
 window.addEventListener('DOMContentLoaded', async function() {
     const appElement = document.getElementById('app');
     appElement.replaceChildren(createContainerLoading());
@@ -19,7 +23,8 @@ window.addEventListener('DOMContentLoaded', async function() {
     function updateResult(filterState) {
         const selectedDevices = getSelectedDevices(devices, filterState);
         updateContainer({
-            cards: getFilteredData(ports, filterState).map(port => {
+            // Deferred: only the cards a window actually mounts get built.
+            cards: getFilteredData(ports, filterState).map(port => () => {
                 return updateCard(getCard(port), port, selectedDevices, firmwareNames);
             }),
         });
@@ -71,19 +76,55 @@ function createContainer({ attributes, devices, genres, onchange }) {
         createElement('div', { className: 'my-2 gap-2 d-flex flex-wrap justify-content-center' }, [dropdownButtons, searchInput, sortElement]),
         createElement('h2', { ref: el => containerRefs.title = el, className: 'my-4 text-center' }),
         createElement('div', { ref: el => containerRefs.list = el, className: 'row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3' }),
+        createElement('div', { ref: el => containerRefs.sentinel = el }),
     ]);
+
+    const showCards = createWindowedList(containerRefs.list, containerRefs.sentinel);
 
     function updateContainer({ cards }) {
         updateDropdowns();
 
         containerRefs.title.textContent = `${cards.length} Ports Available`;
-        batchReplaceChildren(200, containerRefs.list, cards);
+        showCards(cards);
     }
 
     return {
         containerElement,
         updateContainer,
         filterControls,
+    };
+}
+
+/**
+ * Mounts cards a window at a time, extending as the sentinel below the list
+ * scrolls into view. Keeps the DOM proportional to what has been scrolled past
+ * rather than to the full catalogue.
+ */
+function createWindowedList(listElement, sentinelElement) {
+    let queue = [];
+
+    const observer = new IntersectionObserver(entries => {
+        if (entries.some(entry => entry.isIntersecting)) {
+            appendWindow();
+        }
+    }, { rootMargin: WINDOW_ROOT_MARGIN });
+
+    function appendWindow() {
+        listElement.append(...queue.splice(0, WINDOW_SIZE).map(buildCard => buildCard()));
+
+        observer.unobserve(sentinelElement);
+
+        // Re-observing is what keeps this going: IntersectionObserver reports only
+        // changes in state, so a sentinel that stays in view never fires again.
+        if (queue.length !== 0) {
+            observer.observe(sentinelElement);
+        }
+    }
+
+    return function showCards(cards) {
+        queue = [...cards];
+        listElement.replaceChildren();
+        appendWindow();
     };
 }
 //#endregion

--- a/website/js/games.js
+++ b/website/js/games.js
@@ -1,6 +1,17 @@
+// Typing "mario" would otherwise rebuild the whole list five times over.
+const SEARCH_DEBOUNCE_MS = 200;
+
 const WINDOW_SIZE = 60;
 // Extend a screen ahead so scrolling never waits on the next window.
 const WINDOW_ROOT_MARGIN = '800px';
+
+function debounce(func, wait) {
+    let timer;
+    return function (...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => func.apply(this, args), wait);
+    };
+}
 
 window.addEventListener('DOMContentLoaded', async function() {
     const appElement = document.getElementById('app');
@@ -14,7 +25,10 @@ window.addEventListener('DOMContentLoaded', async function() {
     const firmwareNames = getFirmwareNames();
 
     const getCard = memoize(createCard, port => port.name);
-    const { containerElement, updateContainer, filterControls } = createContainer({ attributes, devices, genres, onchange });
+    const { containerElement, updateContainer, filterControls } = createContainer({
+        attributes, devices, genres, onchange,
+        oninput: debounce(onchange, SEARCH_DEBOUNCE_MS),
+    });
     const filterState = defaultFilterState(JSON.parse(sessionStorage.getItem('filterState')));
     setFilterState(filterControls, filterState);
     updateResult(filterState);
@@ -64,9 +78,9 @@ function createSort({ onchange }) {
     return { sortElement, sortRadio };
 }
 
-function createContainer({ attributes, devices, genres, onchange }) {
+function createContainer({ attributes, devices, genres, onchange, oninput }) {
     const { dropdownButtons, checkboxes, updateDropdowns } = createDropdowns({ attributes, devices, genres, onchange });
-    const searchInput = createSearchInput({ oninput: onchange });
+    const searchInput = createSearchInput({ oninput });
     const { sortElement, sortRadio } = createSort({ onchange });
 
     const filterControls = { checkboxes, searchInput, sortRadio };

--- a/website/js/games.js
+++ b/website/js/games.js
@@ -2,8 +2,7 @@ window.addEventListener('DOMContentLoaded', async function() {
     const appElement = document.getElementById('app');
     appElement.replaceChildren(createContainerLoading());
 
-    const ports = await fetchPorts();
-    const deviceInfo = await fetchDeviceInfo();
+    const [ports, deviceInfo] = await Promise.all([fetchPorts(), fetchDeviceInfo()]);
     const attributes = getAttributes(ports);
     const genres = getGenres(ports);
     const deviceCounts = getDeviceCounts(ports);

--- a/website/js/shared.js
+++ b/website/js/shared.js
@@ -56,6 +56,30 @@ async function batchReplaceChildren(batchSize, container, children) {
     }
 }
 
+// cmark-gfm is half a megabyte of asm.js and only the details view renders a
+// README with it, so pages fetch it on first use instead of on every load.
+// Pages that convert markdown immediately still include it with a script tag.
+const CMARK_GFM_SRC = 'js/cmark-gfm.js';
+
+let cmarkGfmLoad;
+
+function loadCmarkGfm() {
+    if (window.CmarkGFM) {
+        return Promise.resolve(window.CmarkGFM);
+    }
+
+    cmarkGfmLoad ??= new Promise((resolve, reject) => {
+        const script = createElement('script', {
+            src: CMARK_GFM_SRC,
+            onload: () => resolve(window.CmarkGFM),
+            onerror: () => reject(new Error(`Failed to load ${CMARK_GFM_SRC}`)),
+        });
+        document.head.append(script);
+    });
+
+    return cmarkGfmLoad;
+}
+
 function memoize(func, resolver) {
     function memoized(...args) {
         const key = resolver ? resolver.apply(this, args) : args[0];
@@ -443,14 +467,14 @@ function updateCard(card, port, selectedDevices, firmwareNames) {
 function createAdditionalInformation(port) {
     const additionalInformation = createElement('div', { style: 'word-wrap: break-word' }, 'Loading...');
 
-    function markdownToHtml(markdown) {
-        return CmarkGFM.convert(markdown.replaceAll('<br/>', ''))
+    function markdownToHtml(cmarkGfm, markdown) {
+        return cmarkGfm.convert(markdown.replaceAll('<br/>', ''))
             .replaceAll('<table>', '<table class="table table-bordered">')
             .replaceAll('<h2>', '<h2 style="margin-top: 1em; margin-bottom: 1em;">');
     }
 
-    fetchReadme(port).then(readme => {
-        additionalInformation.innerHTML = markdownToHtml(readme);
+    Promise.all([fetchReadme(port), loadCmarkGfm()]).then(([readme, cmarkGfm]) => {
+        additionalInformation.innerHTML = markdownToHtml(cmarkGfm, readme);
     });
 
     return additionalInformation;

--- a/website/js/shared.js
+++ b/website/js/shared.js
@@ -80,6 +80,15 @@ function loadCmarkGfm() {
     return cmarkGfmLoad;
 }
 
+// Constructing a Converter rebuilds showdown's option and extension tables, so
+// the one instance is shared across every card and detail view.
+let showdownConverter;
+
+function getShowdownConverter() {
+    showdownConverter ??= new showdown.Converter();
+    return showdownConverter;
+}
+
 function memoize(func, resolver) {
     function memoized(...args) {
         const key = resolver ? resolver.apply(this, args) : args[0];
@@ -387,7 +396,7 @@ function createCard(port) {
                 ]),
                 createElement('div', {
                     className: 'card-text mb-auto',
-                    innerHTML: new showdown.Converter().makeHtml(desc),
+                    innerHTML: getShowdownConverter().makeHtml(desc),
                 }),
                 createElement('p', { className: 'card-text update-supported', hidden: true }),
                 createElement('div', { className: 'd-flex justify-content-between align-items-start' }, [
@@ -500,7 +509,7 @@ function createCardDetails({ port, deviceDetails, additionalInformation }) {
                 createElement('div', { className: 'desc' }, [
                     createElement('p', {
                         className: 'lead mb-4 mt-4',
-                        innerHTML: new showdown.Converter().makeHtml(port.attr.desc_md || port.attr.desc),
+                        innerHTML: getShowdownConverter().makeHtml(port.attr.desc_md || port.attr.desc),
                     }),
                 ]),
                 createElement('div', { className: 'd-grid gap-2 d-sm-flex justify-content-sm-center mb-5' }, [
@@ -588,7 +597,7 @@ function createCardDetails({ port, deviceDetails, additionalInformation }) {
                 createElement('p', {
                     className: 'lead mb-4 mt-4',
                     style: 'word-wrap: break-word',
-                    innerHTML: new showdown.Converter().makeHtml(port.attr.inst_md || port.attr.inst),
+                    innerHTML: getShowdownConverter().makeHtml(port.attr.inst_md || port.attr.inst),
                 }),
             ]),
         ]),

--- a/website/js/shared.js
+++ b/website/js/shared.js
@@ -385,6 +385,9 @@ function createCard(port) {
                     src: imageUrl,
                     className: 'bd-placeholder-img card-img-top object-fit-contain',
                     loading: 'lazy',
+                    // Screenshots are unoptimised repo PNGs; keep them from
+                    // competing with ports.json and the stylesheets.
+                    fetchPriority: 'low',
                 }),
             ]),
             createElement('div', { className: 'card-body d-flex flex-column' }, [

--- a/website/profile.html
+++ b/website/profile.html
@@ -14,7 +14,6 @@
   <script defer src="js/color-modes.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"></script>
-  <script defer src="js/cmark-gfm.js"></script>
   <script defer src="js/shared.js"></script>
   <script defer src="js/profile.js"></script>
 </head>


### PR DESCRIPTION
I am testing the site on handhelds and it is heavy on them, so decided to look at what the site loads. A few small improvements:

- cmark-gfm.js is loaded on demand - `games.html` and `profile.html`  pulled (557 KB ~112 KiB gzipped) of asm.js on every visit, which also has to be  parsed.  But `CmarkGFM` only renders the README inside the details modal. It is now fetched on first  use.
- shared `showdown.Converter` - it was constructed once per card + per detail.
- `fetchpriority="low"` on screenshots -  they competed for bandwidth with `ports.json`, the CSS and the JS.

For the games list:

- windowed rendering - all 1000+ cards were built up front. A card is now built only when a window of 60 mounts it, and the list extends as it comes within 800px of the viewport.
- debounced search - every keystroke rebuilt the list, so  typing a five-letter query did that five times. It now waits 200ms.
- parallel fetches - `device_info.json` waited for `ports.json`, although nothing links them. All three JSON requests for the page go together now.